### PR TITLE
sh1_vin_map_bin: add trigger/POI reading

### DIFF
--- a/010 Editor - Binary Templates/sh1_vin_map_bin_draft.bt
+++ b/010 Editor - Binary Templates/sh1_vin_map_bin_draft.bt
@@ -16,6 +16,8 @@
 typedef uint8 u8_deg <read=Str("%lg deg", this / 352.0 * 360),
                      write=(this = Atof(value) * 352.0 / 360.0)>;
 
+const int MapOverlayAddress = 0x800C9578;
+
 //------------------------------------------------
 // Structs
 //------------------------------------------------
@@ -47,41 +49,194 @@ struct TodoVcRoadData
     uint8 data[24];
 };
 
+enum<byte> POIType
+{
+    POIType_Unk0 = 0,
+    POIType_TouchAabb = 1,
+    POIType_ButtonOmni = 2,
+    POIType_ButtonYaw = 3,
+    POIType_TouchObb = 4,
+    POIType_Dummy = 15
+};
+
+struct PointOfInterest_Button // ButtonOmni / ButtonYaw
+{
+    q19_12 positionX_0;
+    uint32 unk_4_0 : 12;
+    uint32 geo : 12; // TODO: not sure how this is meant to be decoded yet
+    uint32 unk_24 : 8;
+    q19_12 positionZ_8;
+};
+
+struct PointOfInterest_TouchAabb // TouchAabb
+{
+    q19_12 positionX_0;
+    uint32 unk_4_0 : 16;
+    u8_deg radiusX : 8;
+    u8_deg radiusZ : 8;
+    q19_12 positionZ_8;
+};
+
+struct PointOfInterest_TouchObb // TouchObb
+{
+    q19_12 positionX_0;
+    uint32 unk_4_0 : 16;
+    uint32 geoA : 8;
+    uint32 geoB : 8;
+    q19_12 positionZ_8;
+};
+
+struct PointOfInterest
+{
+    q19_12 positionX_0;
+    uint8 triggerData_4[4]; // Likely a union, but we split to different structs above to make struct reading easier.
+    q19_12 positionZ_8;
+};
+
+enum<uint32> TriggerType
+{
+    TriggerType_Unk0 = 0,
+    TriggerType_Unk1 = 1,
+    TriggerType_Unk2 = 2,
+    TriggerType_Unk3 = 3,
+    TriggerType_Unk4 = 4,
+    TriggerType_Door1 = 5,
+    TriggerType_Door2 = 6,
+    TriggerType_Text = 7,
+    TriggerType_Save0 = 8,
+    TriggerType_Save1 = 9,
+    TriggerType_Function = 10,
+    TriggerType_MapScribble = 11,
+    TriggerType_Unk12 = 12,
+    TriggerType_Unk13 = 13,
+    TriggerType_Unk14 = 14,
+    TriggerType_Unk15 = 15,
+};
+
+typedef struct(uint poiAddress)
+{
+    // Fields from https://github.com/ItEndsWithTens/SilentHillMapExaminer/blob/master/src/SHME.ExternalTool.Guts/Trigger.cs
+
+    uint8 Thing0 : 7;
+    uint8 Disabled : 1;
+
+    // Byte 1
+    uint8 Thing1;
+
+    uint16 FiredBitShift : 5;
+    uint16 FiredGroup : 11;
+
+    // Byte 4
+    POIType PoiType : 4;
+    uint8 Thing2 : 4;
+
+    // Byte 5
+    uint8 PoiIndex;
+
+    // Byte 6
+    uint8 Thing3;
+
+    // Byte 7
+    uint8 Thing4;
+
+    TriggerType Type : 5;
+    uint32 TargetIndex : 8;
+    uint32 Thing5 : 6;
+    uint32 Thing6 : 6;
+    uint32 StageIndex : 6;
+    uint32 SomeBool : 1;
+	
+	// Read in POI data as part of this struct
+
+    local long pos = FTell();
+    
+    FSeek(poiAddress + (12 * PoiIndex));
+    if (PoiType == POIType_ButtonOmni || PoiType == POIType_ButtonYaw)
+        PointOfInterest_Button POI_Button;
+    else if(PoiType == POIType_TouchAabb)
+        PointOfInterest_TouchAabb POI_TouchAabb;
+    else if(PoiType == POIType_TouchObb)
+        PointOfInterest_TouchObb POI_TouchObb;
+    else
+        PointOfInterest POI;
+        
+    FSeek(pos);
+} Trigger<read=ReadTrigger>;
+
+string ReadTrigger(Trigger& t)
+{
+    string s;
+    SPrintf(s, "%s POI #%d %s", EnumToString(t.Type), t.PoiIndex, EnumToString(t.PoiType));
+    return s;
+}
+
 //------------------------------------------------
 // Main
 //------------------------------------------------
-struct Map {
-uint8          padding[4];
-uint8          unk_0[8];
-int8           field_8;
-uint8          unk_9[3];
-uint8          unk_C[8];
-int8           field_14;
-uint8          unk_15[3];
-uint8          unk_18[8];
-uint32         mapEventFuncs_20     <format=hex>;  // Points to array of event functions.
-uint8          unk_24[12];
-uint32         mapMessageStrings_30 <format=hex>;  // Points to array of `char*` for each displayed message in the map.
-uint8          unk_34[12];
-uint32         func_40              <format=hex>;
-uint32         func_44              <format=hex>;
-uint8          unk_48[128];
-uint32         func_C8              <format=hex>;
-uint32         func_CC              <format=hex>;
-uint32         func_D0              <format=hex>;  // 0x800C964C
-uint8          unk_D4[24];
-uint32         func_EC              <format=hex>;
-uint8          unk_F0[76];
-uint32         func_13C             <format=hex>;  // 0x800C96B8
-uint8          unk_140[40];
-uint32         func_168             <format=hex>;
-uint8          unk_16C[4];
-uint8          unk_170[36];
-uint32         charaUpdateFuncs[45] <format=hex>;
-ShCharacterId  charaGroupIds[4];
-SpawnInfo      charaSpawns0(charaGroupIds[0])[16];
-SpawnInfo      charaSpawns1(charaGroupIds[1])[16];
-TodoVcRoadData todoVcRoadData[48];
+struct Map
+{
+    local long mapPos = FTell();
+	
+    uint8           padding[4]           <hidden=true>;
+    
+    uint32          field_0; // s_UnkStruct2_Mo*
+    uint32          getMapRoomIdxFunc_4  <format=hex>;
+    int8            field_8;
+    uint8           unk_9[3]             <hidden=true>;
+    uint8           unk_C[4]             <hidden=true>;
+    uint32          func_10              <format=hex>;
+    int8            field_14;
+    uint8           field_15;
+    int8            field_16;
+    int8            field_17;
+    uint32          func_18              <format=hex>;
+    uint32          poiArrayPtr_1C       <format=hex>; // mapAreaLoadParams_1C in decomp
+    uint32          mapEventFuncs_20     <format=hex>; // Points to array of event functions.
+    uint32          triggerArrayPtr_24   <format=hex>;
+    uint32          field_28             <format=hex>; // GsCOORDINATE2*
+    uint32          field_2C             <format=hex>; // s_UnkStruct_MO*
+    uint32          mapMessageStrings_30 <format=hex>; // Points to array of `char*` for each displayed message in the map.
+    uint32          animInfo_34          <format=hex>; // s_AnimInfo*
+    uint8           unk_38[8]            <hidden=true>;
+    uint32          func_40              <format=hex>;
+    uint32          func_44              <format=hex>;
+    // TODO: copy over other fields from decomp
+    uint8           unk_48[128]          <hidden=true>;
+    uint32          func_C8              <format=hex>;
+    uint32          func_CC              <format=hex>;
+    uint32          func_D0              <format=hex>; // 0x800C964C
+    uint8           unk_D4[24]           <hidden=true>;
+    uint32          func_EC              <format=hex>;
+    uint8           unk_F0[76]           <hidden=true>;
+    uint32          func_13C             <format=hex>; // 0x800C96B8
+    uint8           unk_140[40]          <hidden=true>;
+    uint32          func_168             <format=hex>;
+    uint8           unk_16C[4]           <hidden=true>;
+    uint8           unk_170[36]          <hidden=true>;
+    uint32          charaUpdateFuncs[45] <format=hex>;
+    ShCharacterId   charaGroupIds[4];
+    SpawnInfo       charaSpawns0(charaGroupIds[0])[16];
+    SpawnInfo       charaSpawns1(charaGroupIds[1])[16];
+    TodoVcRoadData  todoVcRoadData[48];
+    
+    local uint32 poi_start = mapPos + (map.poiArrayPtr_1C - MapOverlayAddress);
+    local uint32 poi_end = mapPos + (map.mapEventFuncs_20 - MapOverlayAddress);
+    local uint32 poi_size = poi_end - poi_start;
+    
+    local uint32 trigger_start = mapPos + (triggerArrayPtr_24 - MapOverlayAddress);
+    
+    FSeek(poi_start);
+    
+    PointOfInterest pointsOfInterest[poi_size/12];
+    
+    FSeek(trigger_start);
+    local int i = 0;
+    for(i = 0; i < 256; i++) // Doesn't seem trigger count is stored in header, need to loop until we find end value
+    {
+        Trigger triggers(poi_start);
+        if (triggers.PoiType == POIType_Dummy)
+            break;
+    }
 };
 
 if (GetTemplateName() == "sh1_vin_map_bin_draft.bt")


### PR DESCRIPTION
Added code to read in trigger/POI data from the map, based on how SilentHillMapExaminer reads them in, also added a few extra map header fields from decomp.

(in decomp it looks like we call POI struct as AreaLoadParams, maybe we should change that to match with map examiner instead...)

I'd guess PointOfInterest_Button might include flags that say which buttons its checking for, but not sure how to decode it yet, didn't seem SHME handled it.